### PR TITLE
ANDROID: pkvm: x86: Flush did FLPT_DEFAULT_DID for host_ept flush

### DIFF
--- a/arch/x86/kvm/pkvm/vmx/ept.c
+++ b/arch/x86/kvm/pkvm/vmx/ept.c
@@ -166,6 +166,7 @@ static void host_ept_flush_tlb(struct pkvm_pgtable *pgt,
 		kvm_make_request(KVM_REQ_TLB_FLUSH_CURRENT, vcpu);
 		pkvm_kick_vcpu(vcpu);
 	}
+	pkvm_iommu_pt_flush(vaddr, size);
 }
 
 static u64 ept_pgstate_mask(void)

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -533,6 +533,7 @@ int pkvm_intel_iommu_init(void)
 			return ret;
 	}
 	pkvm_register_iommu_ops(&iommu_ops);
+	init_pt_domain();
 	return 0;
 }
 
@@ -541,8 +542,10 @@ int pkvm_get_domain(void *pgd, int did, struct device_domain_info *info, u32 pas
 	struct dmar_domain *domain;
 	int ret;
 
-	if (did == FLPT_DEFAULT_DID)
+	if (did == FLPT_DEFAULT_DID) {
+		pkvm_cache_assign_domain(&pt_domain, did, info, pasid);
 		return 0;
+	}
 
 	domain = pkvm_get_iommu_domain(pgd);
 	if (!domain) {
@@ -562,10 +565,18 @@ int pkvm_get_domain(void *pgd, int did, struct device_domain_info *info, u32 pas
 void pkvm_put_domain(void *pgd, int did, struct device_domain_info *info, u32 pasid)
 {
 	struct dmar_domain *domain;
-	if (did == FLPT_DEFAULT_DID)
+	if (did == FLPT_DEFAULT_DID) {
+		pkvm_cache_unassign_domain(&pt_domain, did, info, pasid);
 		return;
+	}
 	domain = pkvm_get_iommu_domain_noref(pgd);
 	BUG_ON(!domain);
 	pkvm_cache_unassign_domain(domain, did, info, pasid);
 	pkvm_put_iommu_domain(domain);
+}
+
+void pkvm_iommu_pt_flush(unsigned long vaddr, unsigned long size)
+{
+	if (pt_domain.qi_batch)
+		cache_tag_flush_range(&pt_domain, vaddr, vaddr + size - 1, 0);
 }

--- a/drivers/iommu/intel/pkvm/iommu_domain.c
+++ b/drivers/iommu/intel/pkvm/iommu_domain.c
@@ -19,6 +19,14 @@ static DEFINE_HASHTABLE(iommu_domain_hasht, 8);
 static DECLARE_BITMAP(iommu_domains_bitmap, MAX_IOMMU_DOMAIN_NUM);
 static struct dmar_domain iommu_domains[MAX_IOMMU_DOMAIN_NUM];
 static pkvm_spinlock_t iommu_domain_lock = __PKVM_SPINLOCK_UNLOCKED;
+struct dmar_domain pt_domain;
+
+void init_pt_domain(void)
+{
+	INIT_LIST_HEAD(&pt_domain.cache_tags);
+	pkvm_spin_lock_init(&pt_domain.cache_lock);
+	WRITE_ONCE(pt_domain.qi_batch, &pt_domain._qi_batch);
+}
 
 static inline struct dmar_domain *__pkvm_get_iommu_domain_locked(void* pgd, bool inc_ref)
 {

--- a/drivers/iommu/intel/pkvm/iommu_domain.h
+++ b/drivers/iommu/intel/pkvm/iommu_domain.h
@@ -4,6 +4,8 @@
 #ifndef _PKVM_IOMMU_DOMAIN_H_
 #define _PKVM_IOMMU_DOMAIN_H_
 
+struct dmar_domain;
+struct alloc_domain_data;
 int refill_domain_memcache(struct dmar_domain *domain, struct pkvm_memcache *host_mc);
 
 struct dmar_domain *pkvm_alloc_iommu_domain(struct alloc_domain_data *data, bool need_iotlb_sync_map);
@@ -11,5 +13,8 @@ struct dmar_domain *pkvm_get_iommu_domain(void* pgd);
 struct dmar_domain *pkvm_get_iommu_domain_noref(void* pgd);
 void pkvm_put_iommu_domain(struct dmar_domain *domain);
 int pkvm_free_iommu_domain(struct dmar_domain *domain, struct pkvm_memcache *teardown_mc);
+void init_pt_domain(void);
+
+extern struct dmar_domain pt_domain;
 #endif
 

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -109,6 +109,10 @@ int pkvm_iommu_set_lm_ce(struct set_lm_ce_data *data)
 	info.bus = data->bus;
 	info.devfn = data->devfn;
 	info.iommu = iommu;
+	info.ats_qdep = data->ats_qdep;
+	info.ats_supported = data->ats_supported;
+	info.ats_enabled = data->ats_enabled;
+
 	if (data->did == FLPT_DEFAULT_DID) {
 		/*
 		 * Passthrough will break pkvm security guarantees as
@@ -119,18 +123,12 @@ int pkvm_iommu_set_lm_ce(struct set_lm_ce_data *data)
 		 */
 		domain.pgd = __pkvm_va(pkvm_host_ept_root());
 		domain.agaw = level_to_agaw(pkvm_host_ept_level());
-		info.ats_qdep = 0;
-		info.ats_supported = 0;
-		info.ats_enabled = 0;
 	} else {
 		if (data->agaw != iommu->agaw)
 			return -EINVAL;
 
 		domain.pgd = pkvm_host_gpa_to_virt(data->pgd_gpa);
 		domain.agaw = data->agaw;
-		info.ats_qdep = data->ats_qdep;
-		info.ats_supported = data->ats_supported;
-		info.ats_enabled = data->ats_enabled;
 	}
 
 	ret = accept_ts_page_donation(iommu, &data->ts_page_gpa);
@@ -329,6 +327,9 @@ int pkvm_iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 	info.iommu = iommu;
 	dev_iommu.priv = (void *)&info;
 	dev.iommu = &dev_iommu;
+	info.ats_qdep = data->ats_qdep;
+	info.ats_supported = data->ats_supported;
+	info.ats_enabled = data->ats_enabled;
 
 	if (data->did == FLPT_DEFAULT_DID) {
 		/*
@@ -343,18 +344,12 @@ int pkvm_iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 
 		domain.pgd = __pkvm_va(pkvm_host_ept_root());
 		domain.agaw = level_to_agaw(pkvm_host_ept_level());
-		info.ats_qdep = 0;
-		info.ats_supported = 0;
-		info.ats_enabled = 0;
 	} else {
 		if (data->agaw != iommu->agaw)
 			return -EINVAL;
 
 		domain.pgd = pkvm_host_gpa_to_virt(data->ssptptr_gpa);
 		domain.agaw = iommu->agaw;
-		info.ats_qdep = data->ats_qdep;
-		info.ats_supported = data->ats_supported;
-		info.ats_enabled = data->ats_enabled;
 	}
 
 	ret = accept_ts_page_donation(iommu, &data->ts_page_gpa);

--- a/drivers/iommu/intel/pkvm/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm/pkvm_iommu.h
@@ -172,6 +172,7 @@ void pkvm_cache_unassign_domain(struct dmar_domain *domain, u16 did,
 
 int pkvm_get_domain(void *pgd, int did, struct device_domain_info *info, u32 pasid);
 void pkvm_put_domain(void *pgd, int did, struct device_domain_info *info, u32 pasid);
+void pkvm_iommu_pt_flush(unsigned long vaddr, unsigned long size);
 
 int pkvm_intel_iommu_init(void);
 #endif /* !__PKVM_HYP__ */


### PR DESCRIPTION
Global DEVTLB invalidation is not feasible as it necessitates iterating over every device. To address this, introduce a specialized passthrough domain ("pt_domain") to track passthrough devices using cache_tag list.

When the host_ept changes, the invalidation logic now performs the following:
1. Flushes DEVTLB for all tracked passthrough devices.
2. Flushes the IOTLB for the pt_domain using FLPT_DEFAULT_DID.

This ensures efficient cache consistency for passthrough devices during host page table updates without requiring a global device scan.

Bug: 391542119
Upstream-Task: 402758258
Test: Build and Boot

Change-Id: I1b1af6ad97a2c302f2d86687116347ee11d4710c