### PR TITLE
ANDROID: pkvm: x86: Replace qi_submit hypercall with iec_flush

### DIFF
--- a/drivers/iommu/intel/dmar.c
+++ b/drivers/iommu/intel/dmar.c
@@ -1439,10 +1439,6 @@ int qi_submit_sync(struct intel_iommu *iommu, struct qi_desc *desc,
 		return 0;
 
 #ifndef __PKVM_HYP__
-	if (pkvm_enabled()) {
-		return pv_qi_submit_sync(iommu, desc, count, options);
-	}
-
 	type = desc->qw0 & GENMASK_ULL(3, 0);
 
 	if ((type == QI_IOTLB_TYPE || type == QI_EIOTLB_TYPE) &&
@@ -1564,6 +1560,13 @@ void qi_global_iec(struct intel_iommu *iommu)
 {
 	struct qi_desc desc;
 
+#ifndef __PKVM_HYP__
+	if (pkvm_enabled()) {
+		pv_iec_flush(iommu, true, 0, 0);
+		return;
+	}
+#endif
+
 	desc.qw0 = QI_IEC_TYPE;
 	desc.qw1 = 0;
 	desc.qw2 = 0;
@@ -1571,6 +1574,25 @@ void qi_global_iec(struct intel_iommu *iommu)
 
 	/* should never fail */
 	qi_submit_sync(iommu, &desc, 1, 0);
+}
+
+int qi_flush_iec(struct intel_iommu *iommu, int index, int mask)
+{
+	struct qi_desc desc;
+
+#ifndef __PKVM_HYP__
+	if (pkvm_enabled()) {
+		return pv_iec_flush(iommu, false, index, mask);
+	}
+#endif
+
+	desc.qw0 = QI_IEC_IIDEX(index) | QI_IEC_TYPE | QI_IEC_IM(mask)
+		   | QI_IEC_SELECTIVE;
+	desc.qw1 = 0;
+	desc.qw2 = 0;
+	desc.qw3 = 0;
+
+	return qi_submit_sync(iommu, &desc, 1, 0);
 }
 
 void qi_flush_context(struct intel_iommu *iommu, u16 did, u16 sid, u8 fm,

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -1418,6 +1418,7 @@ int dmar_enable_qi(struct intel_iommu *iommu);
 void dmar_disable_qi(struct intel_iommu *iommu);
 int dmar_reenable_qi(struct intel_iommu *iommu);
 void qi_global_iec(struct intel_iommu *iommu);
+int qi_flush_iec(struct intel_iommu *iommu, int index, int mask);
 
 void qi_flush_context(struct intel_iommu *iommu, u16 did,
 		      u16 sid, u8 fm, u64 type);

--- a/drivers/iommu/intel/irq_remapping.c
+++ b/drivers/iommu/intel/irq_remapping.c
@@ -140,19 +140,6 @@ static int alloc_irte(struct intel_iommu *iommu,
 	return index;
 }
 
-static int qi_flush_iec(struct intel_iommu *iommu, int index, int mask)
-{
-	struct qi_desc desc;
-
-	desc.qw0 = QI_IEC_IIDEX(index) | QI_IEC_TYPE | QI_IEC_IM(mask)
-		   | QI_IEC_SELECTIVE;
-	desc.qw1 = 0;
-	desc.qw2 = 0;
-	desc.qw3 = 0;
-
-	return qi_submit_sync(iommu, &desc, 1, 0);
-}
-
 static int modify_irte(struct irq_2_iommu *irq_iommu,
 		       struct irte *irte_modified)
 {

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -399,9 +399,9 @@ static int pkvm_handle_iommu_hypercall(void *in, void *out)
 	int ret;
 
 	switch (data_in->hc_num) {
-	case qi_submit: {
-		struct qi_submit_data *data = &data_in->qi_submit;
-		ret = pkvm_iommu_qi_submit(data);
+	case iec_flush: {
+		struct iec_flush_data *data = &data_in->iec_flush;
+		ret = pkvm_iommu_iec_flush(data);
 		break;
 	}
 	case clear_ce: {

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -15,7 +15,7 @@
 #include "../pasid.h"
 #include "iommu_domain.h"
 
-int pkvm_iommu_qi_submit(struct qi_submit_data *data)
+int pkvm_iommu_iec_flush(struct iec_flush_data *data)
 {
 	struct intel_iommu *iommu = iommu_from_phys(data->phys);
 
@@ -24,8 +24,13 @@ int pkvm_iommu_qi_submit(struct qi_submit_data *data)
 
 	BUG_ON(!iommu->qi);
 
-	return qi_submit_sync(iommu, pkvm_host_gpa_to_virt(data->desc_gpa),
-			      data->count, data->options);
+	if (data->global) {
+		qi_global_iec(iommu);
+		return 0;
+	}
+
+	return qi_flush_iec(iommu, data->index, data->mask);
+
 }
 
 int pkvm_iommu_clear_ce(struct clear_ce_data *data)

--- a/drivers/iommu/intel/pkvm/iommu_hc.h
+++ b/drivers/iommu/intel/pkvm/iommu_hc.h
@@ -9,7 +9,7 @@
 #include <asm/kvm_pkvm.h>
 
 enum iommu_hc_num {
-	qi_submit,
+	iec_flush,
 	clear_ce,
 	set_lm_ce,
 	set_sm_ce,
@@ -22,11 +22,11 @@ enum iommu_hc_num {
 	domain_unmapping,
 };
 
-struct qi_submit_data {
+struct iec_flush_data {
 	u64 phys;
-	u64 desc_gpa;
-	u32 options;
-	u32 count;
+	bool global;
+	u64 index;
+	u64 mask;
 };
 
 struct clear_ce_data {
@@ -142,7 +142,7 @@ struct domain_unmapping_data {
 
 struct iommu_hc_data {
 	union {
-		struct qi_submit_data qi_submit;
+		struct iec_flush_data iec_flush;
 		struct clear_ce_data clear_ce;
 		struct set_lm_ce_data set_lm_ce;
 		struct set_sm_ce_data set_sm_ce;
@@ -158,7 +158,7 @@ struct iommu_hc_data {
 };
 static_assert(sizeof(struct iommu_hc_data) <= PKVM_HC_DATA_MAX_NUM * sizeof(u64));
 
-int pkvm_iommu_qi_submit(struct qi_submit_data *data);
+int pkvm_iommu_iec_flush(struct iec_flush_data *data);
 int pkvm_iommu_clear_ce(struct clear_ce_data *data);
 int pkvm_iommu_set_lm_ce(struct set_lm_ce_data *data);
 int pkvm_iommu_set_sm_ce(struct set_sm_ce_data *data);

--- a/drivers/iommu/intel/pkvm/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm/pkvm_iommu.h
@@ -95,8 +95,7 @@ struct intel_iommu;
 struct device_domain_info;
 struct dmar_domain;
 
-int pv_qi_submit_sync(struct intel_iommu *iommu, struct qi_desc *desc,
-		      unsigned int count, unsigned long options);
+int pv_iec_flush(struct intel_iommu *iommu, bool global, int index, int mask);
 int pv_context_clear(u64 phys, u8 bus, u8 devfn, struct device_domain_info *info);
 int pv_context_mapping(struct intel_iommu *iommu, struct device_domain_info *info,
 		       u8 bus, u8 devfn, u64 pgd_gpa, u16 did, u8 agaw);

--- a/drivers/iommu/intel/pkvm_iommu.c
+++ b/drivers/iommu/intel/pkvm_iommu.c
@@ -103,17 +103,16 @@ int __init pkvm_host_init_iommu(void)
 	return intel_iommu_init();
 }
 
-int pv_qi_submit_sync(struct intel_iommu *iommu, struct qi_desc *desc,
-		      unsigned int count, unsigned long options)
+int pv_iec_flush(struct intel_iommu *iommu, bool global, int index, int mask)
 {
 	union pkvm_hc_data data_in = { 0 }, data_out;
 	struct iommu_hc_data *data = (struct iommu_hc_data *)&data_in;
 
-	data->qi_submit.phys = iommu->reg_phys;
-	data->qi_submit.desc_gpa = virt_to_phys(desc);
-	data->qi_submit.count = count;
-	data->qi_submit.options = options;
-	data->hc_num = qi_submit;
+	data->iec_flush.phys = iommu->reg_phys;
+	data->iec_flush.global = global;
+	data->iec_flush.index = index;
+	data->iec_flush.mask = mask;
+	data->hc_num = iec_flush;
 	return pkvm_hypercall_inout(iommu_hypercall, &data_in, &data_out);
 }
 


### PR DESCRIPTION
All IOMMU Queue Invalidation (QI) types, except for the Interrupt Entry Cache (IEC), are managed internally by pKVM to ensure proper isolation. Consequently, exposing a generic qi_submit hypercall to the host is unnecessary and presents a potential security risk by allowing arbitrary invalidation requests.

Replace the qi_submit hypercall with a specialized iec_flush interface. This explicitly restricts the host to requesting only QI_IEC type invalidations, preventing it from issuing unauthorized or conflicting invalidation descriptors for resources managed by the hypervisor.

Bug: 391542119
Upstream-Task: 402758258
Test: Build and Boot

Change-Id: I9e505a0a73d6a088c5e4b339b63924e4cd1d4b1f